### PR TITLE
Add more tests

### DIFF
--- a/test/test_ioproblem.jl
+++ b/test/test_ioproblem.jl
@@ -34,3 +34,33 @@ end
     @test subproblem.spec == spec[1:2]
     @test subproblem.name == ""
 end
+
+# Tests for MetricProblem
+@testset "MetricProblem Tests" begin
+    # Create a vector of IOExample instances as specification
+    spec = [
+        IOExample(Dict(:var1 => 1, :var2 => 2), 3),
+        IOExample(Dict(:var1 => 4, :var2 => 5), 6),
+        IOExample(Dict(:var1 => 7, :var2 => 8), 9),
+    ]
+    cost_function(x) = 23
+
+    # Test constructor without a name
+    metric1 = MetricProblem(cost_function, spec)
+    @test metric1.name == ""
+    @test metric1.spec === spec
+    @test metric1.cost_function === cost_function
+
+    # Test constructor with a name
+    name = "Test Metric"
+    metric2 = MetricProblem(name, cost_function, spec)
+    @test metric2.name == name
+    @test metric2.spec === spec
+    @test metric2.cost_function === cost_function
+
+    # Test getindex
+    submetric = metric2[1:2]
+    @test isa(submetric, Problem)
+    @test submetric.spec == spec[1:2]
+    @test submetric.name == ""
+end

--- a/test/test_ioproblem.jl
+++ b/test/test_ioproblem.jl
@@ -11,7 +11,11 @@ end
 # Tests for Problem
 @testset "Problem Tests" begin
     # Create a vector of IOExample instances as specification
-    spec = [IOExample(Dict(:var1 => 1, :var2 => 2), 3), IOExample(Dict(:var1 => 4, :var2 => 5), 6)]
+    spec = [
+        IOExample(Dict(:var1 => 1, :var2 => 2), 3),
+        IOExample(Dict(:var1 => 4, :var2 => 5), 6),
+        IOExample(Dict(:var1 => 7, :var2 => 8), 9),
+    ]
 
     # Test constructor without a name
     problem1 = Problem(spec)
@@ -23,4 +27,10 @@ end
     problem2 = Problem(problem_name, spec)
     @test problem2.name == problem_name
     @test problem2.spec === spec
+
+    # Test getindex
+    subproblem = problem2[1:2]
+    @test isa(subproblem, Problem)
+    @test subproblem.spec == spec[1:2]
+    @test subproblem.name == ""
 end

--- a/test/test_ioproblem.jl
+++ b/test/test_ioproblem.jl
@@ -10,29 +10,38 @@ end
 
 # Tests for Problem
 @testset "Problem Tests" begin
-    # Create a vector of IOExample instances as specification
-    spec = [
-        IOExample(Dict(:var1 => 1, :var2 => 2), 3),
-        IOExample(Dict(:var1 => 4, :var2 => 5), 6),
-        IOExample(Dict(:var1 => 7, :var2 => 8), 9),
+    # Example specs to use in the below tests.
+    specs = [
+         [
+            IOExample(Dict(:var1 => 1, :var2 => 2), 3),
+            IOExample(Dict(:var1 => 4, :var2 => 5), 6),
+            IOExample(Dict(:var1 => 7, :var2 => 8), 9),
+        ],
+        AgdaSpecification(x -> 23),
+        SMTSpecification(x -> 23),
+        [Trace(["some", "exec", "path"]), Trace(["another", "path"])],
     ]
 
-    # Test constructor without a name
-    problem1 = Problem(spec)
-    @test problem1.name == ""
-    @test problem1.spec === spec
+    @testset "$(typeof(spec))" for spec in specs
+        # Test constructor without a name
+        problem1 = Problem(spec)
+        @test problem1.name == ""
+        @test problem1.spec === spec
 
-    # Test constructor with a name
-    problem_name = "Test Problem"
-    problem2 = Problem(problem_name, spec)
-    @test problem2.name == problem_name
-    @test problem2.spec === spec
+        # Test constructor with a name
+        problem_name = "Test Problem"
+        problem2 = Problem(problem_name, spec)
+        @test problem2.name == problem_name
+        @test problem2.spec === spec
 
-    # Test getindex
-    subproblem = problem2[1:2]
-    @test isa(subproblem, Problem)
-    @test subproblem.spec == spec[1:2]
-    @test subproblem.name == ""
+        if spec isa Vector{<:IOExample}
+            # Test getindex
+            subproblem = problem2[1:2]
+            @test isa(subproblem, Problem)
+            @test subproblem.spec == spec[1:2]
+            @test subproblem.name == ""
+        end
+    end
 end
 
 # Tests for MetricProblem


### PR DESCRIPTION
Something I noticed while writing these tests: `getindex` for `MetricProblem` returns a `Problem` rather than a `MetricProblem`:
```julia
Base.getindex(p::MetricProblem{Vector{IOExample}}, indices) = Problem(p.spec[indices])
```
Is this intentional?