### PR TITLE
Make getindex on MetricProblem return a MetricProblem

### DIFF
--- a/src/problem.jl
+++ b/src/problem.jl
@@ -99,6 +99,6 @@ end
 Overwrite `Base.getindex` to allow for slicing of input/output-based problems.
 """
 Base.getindex(p::Problem{Vector{IOExample}}, indices) = Problem(p.spec[indices])
-Base.getindex(p::MetricProblem{Vector{IOExample}}, indices) = Problem(p.spec[indices])
+Base.getindex(p::MetricProblem{Vector{IOExample}}, indices) = MetricProblem(p.cost_function, p.spec[indices])
 
 

--- a/test/test_ioproblem.jl
+++ b/test/test_ioproblem.jl
@@ -69,7 +69,8 @@ end
 
     # Test getindex
     submetric = metric2[1:2]
-    @test isa(submetric, Problem)
+    @test isa(submetric, MetricProblem)
     @test submetric.spec == spec[1:2]
     @test submetric.name == ""
+    @test submetric.cost_function === cost_function
 end


### PR DESCRIPTION
It was previously returning a `Problem`. After a conversation with @pwochner, concluded that it should return a MetricProblem instead. I assumed the return value should have the same `cost_function`.

Care should be taken when merging with #13. One of the tests will clash and will need changing.